### PR TITLE
fixed #290

### DIFF
--- a/OpenROV/Command.h
+++ b/OpenROV/Command.h
@@ -5,7 +5,7 @@
 
 #define MAX_ARGS 10
 #define MAX_COMMANDSIZE 40
-#define MAX_COMMANDS 3
+#define MAX_COMMANDS 5 //use 3 for 328p
 #define DATABUFFERSIZE      80
 
 class InternalCommand {

--- a/OpenROV/DeadManSwitch.cpp
+++ b/OpenROV/DeadManSwitch.cpp
@@ -37,7 +37,7 @@ void DeadmanSwitch::device_loop(Command command){
     Serial.print(F("pong:")); Serial.print(command.args[0]); Serial.print(","); Serial.print(millis()); Serial.print(";");
   }
 
-  if ((deadmanSwitchTimer.elapsed (2000)) && _deadmanSwitchArmed) {
+  if ((deadmanSwitchTimer.elapsed (2000)) && _deadmanSwitchArmed && (_deadmanSwitchEnabled == false)) {
     int argsToSend[] = {0}; //include number of parms as fist parm
     command.pushCommand("deptloff",argsToSend);
     command.pushCommand("headloff",argsToSend);

--- a/OpenROV/Thrusters2X1.cpp
+++ b/OpenROV/Thrusters2X1.cpp
@@ -54,13 +54,15 @@ void Thrusters::device_setup(){
 }
 
 void Thrusters::device_loop(Command command){
-  if (command.cmp("mtrmod")) {
+  if (command.cmp("mtrmod1")) {
       port_motor.motor_positive_modifer = command.args[1]/100;
       vertical_motor.motor_positive_modifer = command.args[2]/100;
       starboard_motor.motor_positive_modifer = command.args[3]/100;
-      port_motor.motor_negative_modifer = command.args[4]/100;
-      vertical_motor.motor_negative_modifer = command.args[5]/100;
-      starboard_motor.motor_negative_modifer = command.args[6]/100;
+  }
+  if (command.cmp("mtrmod2")) {
+      port_motor.motor_negative_modifer = command.args[1]/100;
+      vertical_motor.motor_negative_modifer = command.args[2]/100;
+      starboard_motor.motor_negative_modifer = command.args[3]/100;
   }
   if (command.cmp("rmtrmod")) {
       Serial.print(F("mtrmod:"));

--- a/OpenROV_tests/src/sketch.ino
+++ b/OpenROV_tests/src/sketch.ino
@@ -55,6 +55,24 @@ test(injected_command_drops_next_command_to_be_executed_if_outofbuffer)
   assertEqual(1,cmd.args[1]);
 }
 
+test(sending_up_to_max_commands_does_not_create_buffer_overrun){
+  Command cmd;
+  cmd.reset();
+  //since the tail represents last command executed, in the case of a buffer of 3
+  //we can insert int to buffer [0], [1], but when we try inserting in the last
+  //buffer location [2] it will give a buffer overrun because head cannot push in
+  //to the same location as tail.  So effectively we hax MAX_COMMANDS - 1 bufferd
+  //commands.
+  for(int i=0;i<MAX_COMMANDS-1;i++){
+    int argsToSend[] = {1,i}; //include number of parms as fist parm
+    cmd.pushCommand("test4",argsToSend);
+  }
+  cmd.get();
+  //zero command should be unaffected
+  assertEqual(true,cmd.cmp("test4"));
+  assertEqual(0,cmd.args[1]);
+}
+
 void setup()
 {
   Serial.begin(115200);


### PR DESCRIPTION
This goes with changes in the cockpit code. The max_commands were increased because I noticed some of the commands were sending 3 internal commands which would overflow the buffer.
Deadman switch keeps sending shutdown codes repeatedly which I disabled.
Broke the motor modifier settings in to two commands to minimize the chance we overflow the serial buffer in the arduino.
