### PR TITLE
Fix avr-gcc option in travis-ci

### DIFF
--- a/OpenROV/Makefile
+++ b/OpenROV/Makefile
@@ -1,5 +1,4 @@
-export CXXFLAGS="$CXXFLAGS -c -g -Os -Wall -Wextra -fno-exceptions -ffunction-sections"
-
+CXXFLAGS_STD = -c -g -Wextra
 BOARD_TAG    = mega2560
 ARDUINO_PORT = /dev/cu.usb*
 ARDUINO_LIBS = SPI EEPROM Wire Servo

--- a/OpenROV/Makefile
+++ b/OpenROV/Makefile
@@ -1,3 +1,5 @@
+export CXXFLAGS="$CXXFLAGS -c -g -Os -Wall -Wextra -fno-exceptions -ffunction-sections"
+
 BOARD_TAG    = mega2560
 ARDUINO_PORT = /dev/cu.usb*
 ARDUINO_LIBS = SPI EEPROM Wire Servo


### PR DESCRIPTION
Makes the compile options match the Arduino IDE options when travis-ci runs